### PR TITLE
Add support for single-board CAEN devices

### DIFF
--- a/src/hvps/commands/caen/__init__.py
+++ b/src/hvps/commands/caen/__init__.py
@@ -60,7 +60,7 @@ def _parse_response(response: bytes) -> (int, str):
     except UnicodeDecodeError:
         raise ValueError(f"Invalid response: {response}")
 
-    regex = re.compile(r"^#(?:BD:(?P<bd>\d{2}))?,CMD:OK(?:,VAL:(?P<val>.+))?$")
+    regex = re.compile(r"^#(?:BD:(?P<bd>\d{2}),)?,CMD:OK(?:,VAL:(?P<val>.+))?$")
     match = regex.match(response)
     if match is None:
         raise ValueError(f"Invalid response: '{response}'. Could not match regex")

--- a/src/hvps/commands/caen/__init__.py
+++ b/src/hvps/commands/caen/__init__.py
@@ -60,7 +60,7 @@ def _parse_response(response: bytes) -> (int, str):
     except UnicodeDecodeError:
         raise ValueError(f"Invalid response: {response}")
 
-    regex = re.compile(r"^#(?:BD:(?<bd>\d{2}))?,CMD:OK(?:,VAL:(?<val>.+))?$")
+    regex = re.compile(r"^#(?:BD:(?P<bd>\d{2}))?,CMD:OK(?:,VAL:(?P<val>.+))?$")
     match = regex.match(response)
     if match is None:
         raise ValueError(f"Invalid response: '{response}'. Could not match regex")

--- a/src/hvps/commands/caen/__init__.py
+++ b/src/hvps/commands/caen/__init__.py
@@ -60,7 +60,7 @@ def _parse_response(response: bytes) -> (int, str):
     except UnicodeDecodeError:
         raise ValueError(f"Invalid response: {response}")
 
-    regex = re.compile(r"^#(?:BD:(?P<bd>\d{2}),)?,CMD:OK(?:,VAL:(?P<val>.+))?$")
+    regex = re.compile(r"^#(?:BD:(?P<bd>\d{2}),)?CMD:OK(?:,VAL:(?P<val>.+))?$")
     match = regex.match(response)
     if match is None:
         raise ValueError(f"Invalid response: '{response}'. Could not match regex")


### PR DESCRIPTION
My single module CAEN Supply (R8034N) deliveres its response without the "BD:00" part, which is why the _parse_response function threw an error.
I edited the regular expression in the _parse_response function to accomodate the missing board number.
If the board number is missing, it implicitly assumes its board number 0, and returns that. This might be considered a bit of a hack, but I cant think of any cases where this could become a problem.

Thanks for this great library!