### PR TITLE
CAEN imrange getter and setter datatypes are now consistent

### DIFF
--- a/src/hvps/devices/caen/channel.py
+++ b/src/hvps/devices/caen/channel.py
@@ -159,7 +159,7 @@ class Channel(BaseChannel):
         )
         if response not in ["HIGH", "LOW"]:
             raise ValueError(f"Unexpected response {response}")
-        return response == "HIGH"
+        return response
 
     @property
     def imdec(self) -> int:

--- a/src/hvps/devices/caen/channel.py
+++ b/src/hvps/devices/caen/channel.py
@@ -150,7 +150,7 @@ class Channel(BaseChannel):
         return float(response)
 
     @property
-    def imrange(self) -> bool:
+    def imrange(self) -> str:
         response = _write_command(
             ser=self._serial,
             logger=self._logger,
@@ -485,7 +485,8 @@ class Channel(BaseChannel):
             raise ValueError(f"Could not set PDWN to {value}")
 
     @imrange.setter
-    def imrange(self, value: float) -> None:
+    def imrange(self, value: str) -> None:
+        """Set channel to "HIGH" or "LOW" current monitor mode"""
         _write_command(
             ser=self._serial,
             logger=self._logger,


### PR DESCRIPTION
When trying to set IMRANGE on my CAEN supply, it raised the error `Could not set IMRANGE to LOW` after the comparison `if self.imrange != value:` in `hvps/devices/caen/channel.py` line 496.
This is because the imrange setter expects a string "HIGH" or "LOW", but the getter returns a bool, which is why the comparison has to fail.

I changed the getter to also return the bare string ("HIGH" or "LOW"), which resolves the problem.

