### PR TITLE
Use Python contexts to properly handle serial connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ import logging
 # connection interface is common to all HVPS
 # if no serial port is specified, the first available port will be used
 # if no baudrate is specified, the default baudrate will be used
-# if connect=False, the connection will not be established (useful for testing)
 # if logging_level is specified, the logger will be configured accordingly
-hvps = Caen(port="/dev/ttyUSB0", baudrate=115200, connect=True, logging_level=logging.DEBUG)
-
-# connection settings can be accessed
-print(f"port: {hvps.port}")
-print(f"baudrate: {hvps.baudrate}")
+with Caen(port="/dev/ttyUSB0", baudrate=115200, logging_level=logging.DEBUG) as hvps:
+    # using context manager (with) is recommended, but not required.
+    # If not used, the connection must be opened and closed manually (hvps.open() and hvps.close())
+    # connection settings can be accessed
+    print(f"port: {hvps.port}")
+    print(f"baudrate: {hvps.baudrate}")
 ```
 
 ### Module
@@ -67,13 +67,12 @@ print(f"baudrate: {hvps.baudrate}")
 from hvps import Caen
 
 # default connection settings
-caen = Caen()
+with Caen() as caen:
+    module = caen.module()  # get the first module (module 0)
+    # if multiple modules are present, they can be accessed by index e.g. caen.module(1)
 
-module = caen.module()  # get the first module (module 0)
-# if multiple modules are present, they can be accessed by index e.g. caen.module(1)
-
-# get the module's name
-print(f"module name: {module.name}")
+    # get the module's name
+    print(f"module name: {module.name}")
 ```
 
 ### Channel
@@ -81,22 +80,22 @@ print(f"module name: {module.name}")
 ```python
 from hvps import Caen
 
-caen = Caen()
-module = caen.module(0)
+with Caen() as caen:
+    module = caen.module(0)
 
-print(f"number of channels: {module.number_of_channels}")
+    print(f"number of channels: {module.number_of_channels}")
 
-channel = module.channel(2)  # get channel number 2
+    channel = module.channel(2)  # get channel number 2
 
-# get monitoring parameters
-print(f"vmon: {channel.vmon}")
-print(f"vset: {channel.vset}")
+    # get monitoring parameters
+    print(f"vmon: {channel.vmon}")
+    print(f"vset: {channel.vset}")
 
-# set values (remote mode must be enabled)
-# turn on channel
-channel.turn_on()
+    # set values (remote mode must be enabled)
+    # turn on channel
+    channel.turn_on()
 
-channel.vset = 300.0  # 300 V
+    channel.vset = 300.0  # 300 V
 ```
 
 ## ⚠️ Disclaimer

--- a/src/hvps/devices/hvps.py
+++ b/src/hvps/devices/hvps.py
@@ -17,7 +17,6 @@ class Hvps:
         baudrate: int = 115200,
         port: str | None = None,
         timeout: float | None = None,
-        connect: bool = True,
         logging_level=logging.WARNING,
     ):
         """Initialize the HVPS (High-Voltage Power Supply) object.
@@ -26,7 +25,6 @@ class Hvps:
             baudrate (int, optional): The baud rate for serial communication. Defaults to 115200.
             port (str | None, optional): The serial port to use. If None, it will try to detect one automatically. Defaults to None.
             timeout (float | None, optional): The timeout for serial communication. Defaults to None.
-            connect (bool, optional): Whether to connect to the serial port during initialization. Defaults to True.
             logging_level (int, optional): The logger level. Defaults to logger.WARNING.
 
         """
@@ -59,15 +57,11 @@ class Hvps:
                     )
 
         self._serial: serial.Serial = serial.Serial()
-        self._serial.port = port
-        self._logger.info(f"Using port {port}")
-        self._serial.baudrate = baudrate
-        self._logger.info(f"Using baud rate {self._serial.baudrate}")
-        self._serial.timeout = timeout
-        self._logger.debug(f"Using timeout {self._serial.timeout}")
 
-        if connect:
-            self.connect()
+        self._serial.port = port
+        self._serial.baudrate = baudrate
+        if timeout is not None:
+            self._serial.timeout = timeout
 
     def __del__(self):
         """Cleanup method to close the serial port when the HVPS object is deleted."""
@@ -79,6 +73,9 @@ class Hvps:
         """
 
         self._logger.debug("Connecting to serial port")
+        self._logger.info(f"Using port {self._serial.port}")
+        self._logger.info(f"Using baud rate {self._serial.baudrate}")
+        self._logger.debug(f"Using timeout {self._serial.timeout}")
 
         if not hasattr(self, "_serial"):
             return

--- a/src/hvps/devices/hvps.py
+++ b/src/hvps/devices/hvps.py
@@ -6,7 +6,6 @@ from typing import Dict
 import logging
 import uuid
 import threading
-from contextlib import contextmanager
 
 from .module import Module
 
@@ -86,6 +85,13 @@ class Hvps:
         else:
             self._logger.warning("Serial port is already open")
 
+    def open(self):
+        """
+        Open the serial port. (Alias for connect).
+        """
+
+        self.connect()
+
     def disconnect(self):
         """
         Close the serial port.
@@ -102,18 +108,21 @@ class Hvps:
 
     def close(self):
         """
-        Close the serial port.
+        Close the serial port. (Alias for disconnect).
         """
         self.disconnect()
 
-    @contextmanager
-    def open(self):
+    def __enter__(self) -> Hvps:
         """
-        A context manager to automatically open and close the serial port.
+        Context manager enter method.
         """
-
         self.connect()
-        yield
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Context manager exit method.
+        """
         self.disconnect()
 
     @property

--- a/src/hvps/devices/hvps.py
+++ b/src/hvps/devices/hvps.py
@@ -46,20 +46,13 @@ class Hvps(ABC):
 
         self._modules: Dict[int, Module] = {}
 
-        if port is None:
-            self._logger.info("No port specified, trying to detect one")
-            ports = [port.device for port in list_ports.comports()]
-            if len(ports) >= 1:
-                port = ports[0]
-                if len(ports) > 1:
-                    self._logger.warning(
-                        f"Multiple ports detected: {ports}, using the first one: {port}"
-                    )
-
         self._serial: serial.Serial = serial.Serial()
 
-        self._serial.port = port
         self._serial.baudrate = baudrate
+
+        if port is not None:
+            self._serial.port = port
+
         if timeout is not None:
             self._serial.timeout = timeout
 
@@ -73,6 +66,17 @@ class Hvps(ABC):
         """
 
         self._logger.debug("Connecting to serial port")
+
+        if self.port is None:
+            self._logger.info("No port specified, trying to detect one")
+            ports = [port.device for port in list_ports.comports()]
+            if len(ports) >= 1:
+                self._serial.port = ports[0]
+                if len(ports) > 1:
+                    self._logger.warning(
+                        f"Multiple ports detected: {ports}, using the first one: {self._serial.port}"
+                    )
+
         self._logger.info(f"Using port {self._serial.port}")
         self._logger.info(f"Using baud rate {self._serial.baudrate}")
         self._logger.debug(f"Using timeout {self._serial.timeout}")

--- a/src/hvps/devices/hvps.py
+++ b/src/hvps/devices/hvps.py
@@ -159,6 +159,16 @@ class Hvps:
         """
         return self._serial.baudrate
 
+    @baudrate.setter
+    def baudrate(self, baudrate: int):
+        """
+        Set the baud rate.
+
+        Args:
+            baudrate (int): The baud rate.
+        """
+        self._serial.baudrate = baudrate
+
     @property
     def timeout(self) -> float:
         """
@@ -168,6 +178,18 @@ class Hvps:
             float: The timeout.
         """
         return self._serial.timeout
+
+    @timeout.setter
+    def timeout(self, timeout: float):
+        """
+        Set the timeout.
+
+        Args:
+            timeout (float): The timeout.
+        """
+        if timeout < 0:
+            raise ValueError("Timeout must be positive")
+        self._serial.timeout = timeout
 
     @property
     def serial(self):

--- a/src/hvps/devices/hvps.py
+++ b/src/hvps/devices/hvps.py
@@ -6,6 +6,7 @@ from typing import Dict
 import logging
 import uuid
 import threading
+from contextlib import contextmanager
 
 from .module import Module
 
@@ -69,17 +70,41 @@ class Hvps:
 
     def __del__(self):
         """Cleanup method to close the serial port when the HVPS object is deleted."""
-        if hasattr(self, "_serial"):
-            self._serial.close()
+        self.close()
+
+    def connect(self):
+        """
+        Open the serial port.
+        """
+        if not hasattr(self, "_serial"):
+            return
+        if not self._serial.is_open:
+            self._serial.open()
 
     def disconnect(self):
         """
-        Disconnect from the serial port.
+        Close the serial port.
         """
         if not hasattr(self, "_serial"):
             return
         if self._serial.is_open:
             self._serial.close()
+
+    def close(self):
+        """
+        Close the serial port.
+        """
+        self.disconnect()
+
+    @contextmanager
+    def open(self):
+        """
+        A context manager to automatically open and close the serial port.
+        """
+
+        self.connect()
+        yield
+        self.disconnect()
 
     @property
     def connected(self) -> bool:
@@ -149,12 +174,6 @@ class Hvps:
             level (int): The logging level.
         """
         self._logger.setLevel(level)
-
-    def connect(self):
-        """
-        Connect to the serial port.
-        """
-        self._serial.open()
 
     # modules
 

--- a/src/hvps/devices/hvps.py
+++ b/src/hvps/devices/hvps.py
@@ -6,11 +6,12 @@ from typing import Dict
 import logging
 import uuid
 import threading
+from abc import ABC, abstractmethod
 
 from .module import Module
 
 
-class Hvps:
+class Hvps(ABC):
     def __init__(
         self,
         baudrate: int = 115200,
@@ -83,7 +84,7 @@ class Hvps:
         if not self._serial.is_open:
             self._serial.open()
         else:
-            self._logger.warning("Serial port is already open")
+            self._logger.debug("Serial port is already open")
 
     def open(self):
         """
@@ -104,7 +105,7 @@ class Hvps:
         if self._serial.is_open:
             self._serial.close()
         else:
-            self._logger.warning("Serial port is already closed")
+            self._logger.debug("Serial port is already closed")
 
     def close(self):
         """
@@ -238,6 +239,7 @@ class Hvps:
         """
         return self._modules
 
+    @abstractmethod
     def module(self, module: int = 0) -> Module:
         """Get the specified module.
 
@@ -250,6 +252,4 @@ class Hvps:
         Raises:
             KeyError: If the module number is invalid.
         """
-        if module not in self._modules:
-            raise KeyError(f"Invalid module {module}")
-        return self._modules[module]
+        pass

--- a/src/hvps/devices/iseg/iseg.py
+++ b/src/hvps/devices/iseg/iseg.py
@@ -27,3 +27,10 @@ class Iseg(Hvps):
             )
             for i in [0]
         }
+
+    def module(self, module: int = 0) -> Module:
+        self._logger.debug(f"Getting module {module}")
+        if module in self._modules.keys():
+            return self._modules[module]
+        else:
+            raise ValueError(f"Module {module} does not exist")

--- a/tests/test_caen_devices.py
+++ b/tests/test_caen_devices.py
@@ -2,16 +2,6 @@ from hvps import Caen
 import pytest
 
 
-def test_caen_init(caplog):
-    caplog.set_level("DEBUG")
-
-    with Caen(logging_level="DEBUG") as caen:
-        assert caen.baudrate == 115200
-        assert "Using baud rate 115200" in caplog.text
-        assert "Using port " in caplog.text
-        assert "Using timeout " in caplog.text
-
-
 def test_caen_module(caplog):
     caplog.set_level("DEBUG")
 

--- a/tests/test_caen_devices.py
+++ b/tests/test_caen_devices.py
@@ -5,16 +5,11 @@ import pytest
 def test_caen_init(caplog):
     caplog.set_level("DEBUG")
 
-    Caen()
-
-    assert caplog.text == ""
-
-    caen = Caen(logging_level="DEBUG")
-
-    assert caen.baudrate == 115200
-    assert "Using baud rate 115200" in caplog.text
-    assert "Using port " in caplog.text
-    assert "Using timeout " in caplog.text
+    with Caen(logging_level="DEBUG") as caen:
+        assert caen.baudrate == 115200
+        assert "Using baud rate 115200" in caplog.text
+        assert "Using port " in caplog.text
+        assert "Using timeout " in caplog.text
 
 
 def test_caen_module(caplog):

--- a/tests/test_caen_devices.py
+++ b/tests/test_caen_devices.py
@@ -5,11 +5,11 @@ import pytest
 def test_caen_init(caplog):
     caplog.set_level("DEBUG")
 
-    Caen(connect=False)
+    Caen()
 
     assert caplog.text == ""
 
-    caen = Caen(connect=False, logging_level="DEBUG")
+    caen = Caen(logging_level="DEBUG")
 
     assert caen.baudrate == 115200
     assert "Using baud rate 115200" in caplog.text
@@ -20,7 +20,7 @@ def test_caen_init(caplog):
 def test_caen_module(caplog):
     caplog.set_level("DEBUG")
 
-    caen = Caen(connect=False, logging_level="DEBUG")
+    caen = Caen(logging_level="DEBUG")
 
     # for CAEN, modules are dynamically created
     [caen.module(i) for i in range(0, 32)]
@@ -38,7 +38,7 @@ def test_caen_module(caplog):
 def test_caen_channel(caplog):
     caplog.set_level("DEBUG")
 
-    caen = Caen(connect=False, logging_level="DEBUG")
+    caen = Caen(logging_level="DEBUG")
 
     module = caen.module()
 

--- a/tests/test_caen_serial.py
+++ b/tests/test_caen_serial.py
@@ -33,10 +33,11 @@ def test_caen_module_monitor():
     caen = Caen(
         port=serial_port,
         baudrate=serial_baud,
-        connect=True,
         timeout=timeout,
         logging_level=logging.DEBUG,
     )
+    caen.connect()
+
     print(
         f"Serial port status: connected: {caen.connected}, port: {caen.port}, baudrate: {caen.baudrate}, timeout: {caen.timeout}"
     )
@@ -90,16 +91,19 @@ def test_caen_module_monitor():
     channels = module.channels
     print(f"Channels: {channels}")
 
+    caen.disconnect()
+
 
 @serial_skip_decorator
 def test_caen_channel_serial():
     caen = Caen(
         port=serial_port,
         baudrate=serial_baud,
-        connect=True,
         timeout=timeout,
         logging_level=logging.DEBUG,
     )
+    caen.connect()
+
     print(
         f"Serial port status: connected: {caen.connected}, port: {caen.port}, baudrate: {caen.baudrate}, timeout: {caen.timeout}"
     )
@@ -201,3 +205,5 @@ def test_caen_channel_serial():
 
         stat = channel.stat
         print(f"stat: {stat}")
+
+    caen.disconnect()

--- a/tests/test_caen_serial.py
+++ b/tests/test_caen_serial.py
@@ -28,6 +28,17 @@ serial_skip_decorator = pytest.mark.skipif(
 
 
 @serial_skip_decorator
+def test_caen_init(caplog):
+    caplog.set_level("DEBUG")
+
+    with Caen(logging_level="DEBUG") as caen:
+        assert caen.baudrate == 115200
+        assert "Using baud rate 115200" in caplog.text
+        assert "Using port " in caplog.text
+        assert "Using timeout " in caplog.text
+
+
+@serial_skip_decorator
 def test_caen_module_monitor():
     # no ports available
     caen = Caen(

--- a/tests/test_iseg_devices.py
+++ b/tests/test_iseg_devices.py
@@ -5,16 +5,11 @@ import pytest
 def test_iseg_init(caplog):
     caplog.set_level("DEBUG")
 
-    Iseg()
-
-    assert caplog.text == ""
-
-    iseg = Iseg(logging_level="DEBUG")
-
-    assert iseg.baudrate == 115200
-    assert "Using baud rate 115200" in caplog.text
-    assert "Using port " in caplog.text
-    assert "Using timeout " in caplog.text
+    with Iseg(logging_level="DEBUG") as iseg:
+        assert iseg.baudrate == 115200
+        assert "Using baud rate 115200" in caplog.text
+        assert "Using port " in caplog.text
+        assert "Using timeout " in caplog.text
 
 
 def test_iseg_module(caplog):

--- a/tests/test_iseg_devices.py
+++ b/tests/test_iseg_devices.py
@@ -5,11 +5,11 @@ import pytest
 def test_iseg_init(caplog):
     caplog.set_level("DEBUG")
 
-    Iseg(connect=False)
+    Iseg()
 
     assert caplog.text == ""
 
-    iseg = Iseg(connect=False, logging_level="DEBUG")
+    iseg = Iseg(logging_level="DEBUG")
 
     assert iseg.baudrate == 115200
     assert "Using baud rate 115200" in caplog.text
@@ -18,7 +18,7 @@ def test_iseg_init(caplog):
 
 
 def test_iseg_module(caplog):
-    iseg = Iseg(connect=False)
+    iseg = Iseg()
 
     # for ISEG only one module exists
     iseg.module()
@@ -35,7 +35,7 @@ def test_iseg_module(caplog):
 def test_iseg_channel(caplog):
     caplog.set_level("DEBUG")
 
-    iseg = Iseg(connect=False, logging_level="DEBUG")
+    iseg = Iseg(logging_level="DEBUG")
 
     module = iseg.module()
 

--- a/tests/test_iseg_devices.py
+++ b/tests/test_iseg_devices.py
@@ -2,16 +2,6 @@ from hvps import Iseg
 import pytest
 
 
-def test_iseg_init(caplog):
-    caplog.set_level("DEBUG")
-
-    with Iseg(logging_level="DEBUG") as iseg:
-        assert iseg.baudrate == 115200
-        assert "Using baud rate 115200" in caplog.text
-        assert "Using port " in caplog.text
-        assert "Using timeout " in caplog.text
-
-
 def test_iseg_module(caplog):
     iseg = Iseg()
 

--- a/tests/test_iseg_serial.py
+++ b/tests/test_iseg_serial.py
@@ -35,6 +35,7 @@ def test_iseg_module_monitor():
         timeout=timeout,
         logging_level=logging.DEBUG,
     )
+    iseg.connect()
 
     print(
         f"Serial port status: connected: {iseg.connected}, port: {iseg.port}, baudrate: {iseg.baudrate}, timeout: {iseg.timeout}"
@@ -172,12 +173,14 @@ def test_iseg_module_monitor():
     module.reset_module_event_status()
     module.clear_module_event_status_bits(8)
 
+    iseg.disconnect()
+
 
 @serial_skip_decorator
 def test_iseg_channel_monitor():
     ser = serial.Serial(serial_port, serial_baud, timeout=timeout)
 
-    channel = Channel(ser, 0)
+    channel = Channel(ser, 0)  # TODO: what is this 0?
 
     trip_action = channel.trip_action
     print(f"trip_action: {trip_action}")

--- a/tests/test_iseg_serial.py
+++ b/tests/test_iseg_serial.py
@@ -27,6 +27,17 @@ serial_skip_decorator = pytest.mark.skipif(
 
 
 @serial_skip_decorator
+def test_iseg_init(caplog):
+    caplog.set_level("DEBUG")
+
+    with Iseg(logging_level="DEBUG") as iseg:
+        assert iseg.baudrate == 115200
+        assert "Using baud rate 115200" in caplog.text
+        assert "Using port " in caplog.text
+        assert "Using timeout " in caplog.text
+
+
+@serial_skip_decorator
 def test_iseg_module_monitor():
     iseg = Iseg(
         port=serial_port,


### PR DESCRIPTION
There are some inconsistencies detected while running tests where the tests fail due to serial connection no being properly closed.  This PR implements a way to properly handle the serial connection:

- Use of `with`:
```
with Caen() as caen:
    ...
```

- Manually open and close:
```
caen = Caen()
caen.open()
...
caen.close()
```